### PR TITLE
Delete shaders after linking

### DIFF
--- a/src/comp3170/Shader.java
+++ b/src/comp3170/Shader.java
@@ -98,6 +98,13 @@ public class Shader {
 		gl.glAttachShader(this.program, fragmentShader);
 		gl.glLinkProgram(program);
 		GLException.checkGLErrors();
+		
+		// delete the shaders after linking
+		
+		gl.glDetachShader(this.program, vertexShader);
+		gl.glDetachShader(this.program, fragmentShader);
+		gl.glDeleteShader(vertexShader);
+		gl.glDeleteShader(fragmentShader);
 
 		// check for linker errors
 
@@ -769,6 +776,9 @@ public class Shader {
 				logString = new String(log);
 			}
 
+			// delete the shader if the compilation failed
+			gl.glDeleteShader(shader);
+			
 			String message = String.format("%s: compilation error\n%s", sourceFile.getName(), logString);
 			throw new GLException(message);
 		}


### PR DESCRIPTION
Improve resource management by deleting the shader objects after the program is linked and they are no longer needed.