### PR TITLE
Add shader debug mode

### DIFF
--- a/src/comp3170/Shader.java
+++ b/src/comp3170/Shader.java
@@ -45,6 +45,9 @@ public class Shader {
 	private Map<String, Integer> uniforms;
 	private Map<String, Integer> uniformTypes;
 
+	private Map<String, Boolean> trackedAttributeErrors;
+	private Map<String, Boolean> trackedUniformErrors;
+	
 	private FloatBuffer matrix2Buffer = Buffers.newDirectFloatBuffer(4);
 	private FloatBuffer matrix3Buffer = Buffers.newDirectFloatBuffer(9);
 	private FloatBuffer matrix4Buffer = Buffers.newDirectFloatBuffer(16);
@@ -155,10 +158,11 @@ public class Shader {
 			String message = String.format("Unknown attribute: '%s'", name);
 			if(!SHADER_DEBUG_MODE) {
 				throw new IllegalArgumentException(String.format("%s\nTo prevent crashes, call 'Shader.setDebugMode(true);' in your program.", message));
-			} else {
+			} else if(!this.trackedAttributeErrors.containsKey(name)) {
 				System.err.println(message);
-				return -1;
+				this.trackedAttributeErrors.put(name, true);
 			}
+			return -1;
 		}
 
 		return this.attributes.get(name);
@@ -176,10 +180,11 @@ public class Shader {
 			String message = String.format("Unknown uniform: '%s'", name);
 			if(!SHADER_DEBUG_MODE) {
 				throw new IllegalArgumentException(String.format("%s\nTo prevent crashes, call 'Shader.setDebugMode(true);' in your program.", message));
-			} else {
+			} else if(!this.trackedUniformErrors.containsKey(name)) {
 				System.err.println(message);
-				return -1;
+				this.trackedUniformErrors.put(name, true);
 			}
+			return -1;
 		}
 
 		return this.uniforms.get(name);
@@ -663,6 +668,7 @@ public class Shader {
 
 		this.attributes = new HashMap<String, Integer>();
 		this.attributeTypes = new HashMap<String, Integer>();
+		this.trackedAttributeErrors = new HashMap<String, Boolean>();
 
 		int[] iBuff = new int[1];
 		gl.glGetProgramiv(this.program, GL_ACTIVE_ATTRIBUTES, iBuff, 0);
@@ -695,6 +701,7 @@ public class Shader {
 
 		this.uniforms = new HashMap<String, Integer>();
 		this.uniformTypes = new HashMap<String, Integer>();
+		this.trackedUniformErrors = new HashMap<String, Boolean>();
 
 		int[] iBuff = new int[1];
 		gl.glGetProgramiv(this.program, GL_ACTIVE_UNIFORMS, iBuff, 0);

--- a/src/comp3170/Shader.java
+++ b/src/comp3170/Shader.java
@@ -36,6 +36,8 @@ import com.jogamp.opengl.GLContext;
 
 public class Shader {
 
+	private static boolean SHADER_DEBUG_MODE = false;
+	
 	private int program;
 	private int vao;
 	private Map<String, Integer> attributes;
@@ -150,7 +152,13 @@ public class Shader {
 
 	public int getAttribute(String name) {
 		if (!this.attributes.containsKey(name)) {
-			throw new IllegalArgumentException(String.format("Unknown attribute: '%s'", name));
+			String message = String.format("Unknown attribute: '%s'", name);
+			if(!SHADER_DEBUG_MODE) {
+				throw new IllegalArgumentException(String.format("%s\nTo prevent crashes, call 'Shader.setDebugMode(true);' in your program.", message));
+			} else {
+				System.err.println(message);
+				return -1;
+			}
 		}
 
 		return this.attributes.get(name);
@@ -165,7 +173,13 @@ public class Shader {
 
 	public int getUniform(String name) {
 		if (!this.uniforms.containsKey(name)) {
-			throw new IllegalArgumentException(String.format("Unknown uniform: '%s'", name));
+			String message = String.format("Unknown uniform: '%s'", name);
+			if(!SHADER_DEBUG_MODE) {
+				throw new IllegalArgumentException(String.format("%s\nTo prevent crashes, call 'Shader.setDebugMode(true);' in your program.", message));
+			} else {
+				System.err.println(message);
+				return -1;
+			}
 		}
 
 		return this.uniforms.get(name);
@@ -321,8 +335,9 @@ public class Shader {
 	public void setAttribute(String attributeName, int buffer) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int attribute = getAttribute(attributeName);
+		if(attribute < 0) return;
+		
 		int type = attributeTypes.get(attributeName);
-
 		GLBuffers.checkType(buffer, type);
 
 		int size = GLTypes.typeSize(type);
@@ -342,6 +357,8 @@ public class Shader {
 	public void setUniform(String uniformName, boolean value) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
 
 		switch (type) {
@@ -362,6 +379,8 @@ public class Shader {
 	public void setUniform(String uniformName, int value) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
 
 		switch (type) {
@@ -386,6 +405,8 @@ public class Shader {
 	public void setUniform(String uniformName, float value) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
 
 		if (type != GL_FLOAT) {
@@ -408,8 +429,9 @@ public class Shader {
 	public void setUniform(String uniformName, int[] value) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
-
 		int expectedArgs = GLTypes.typeSize(type);
 
 		if (value.length != expectedArgs) {
@@ -461,8 +483,9 @@ public class Shader {
 	public void setUniform(String uniformName, float[] value) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
-
 		int expectedArgs = GLTypes.typeSize(type);
 
 		if (value.length != expectedArgs) {
@@ -510,6 +533,8 @@ public class Shader {
 	public void setUniform(String uniformName, Vector2f vector) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
 
 		if (type != GL_FLOAT_VEC2) {
@@ -529,6 +554,8 @@ public class Shader {
 	public void setUniform(String uniformName, Vector3f vector) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
 
 		if (type != GL_FLOAT_VEC3) {
@@ -548,6 +575,8 @@ public class Shader {
 	public void setUniform(String uniformName, Vector4f vector) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
 
 		if (type != GL_FLOAT_VEC4) {
@@ -567,6 +596,8 @@ public class Shader {
 	public void setUniform(String uniformName, Matrix2f matrix) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
 
 		if (type != GL_FLOAT_MAT2) {
@@ -586,6 +617,8 @@ public class Shader {
 	public void setUniform(String uniformName, Matrix3f matrix) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
 
 		if (type != GL_FLOAT_MAT3) {
@@ -605,6 +638,8 @@ public class Shader {
 	public void setUniform(String uniformName, Matrix4f matrix) {
 		GL4 gl = (GL4) GLContext.getCurrentGL();
 		int uniform = getUniform(uniformName);
+		if(uniform < 0) return;
+		
 		int type = uniformTypes.get(uniformName);
 
 		if (type != GL_FLOAT_MAT4) {
@@ -763,6 +798,15 @@ public class Shader {
 		return shader;
 	}
 
+	/**
+	 * Enables/disables debug mode which will determine if missing uniform/attributes
+	 * will throw an error or just print a message.
+	 * @param enabled Whether debug mode is enabled or disabled
+	 */
+	public static void setDebugMode(boolean enabled) {
+		SHADER_DEBUG_MODE = enabled;
+	}
+	
 	/**
 	 * Turn a shader type constant into a descriptive string.
 	 * 


### PR DESCRIPTION
The current shader class will throw an error and usually crash the program if you attempt to set a missing attribute/uniform value. This unfortunately can make debugging shaders very difficult since the GLSL compiler will optimise out unused uniform variables, causing the program to crash.

This adds an optional debug mode to the shader class which will simply print an error message about the missing uniform/attribute rather than throwing an exception. This is disabled by default and must be manually enabled by calling `Shader.setDebugMode(true)`, which should encourage students to only enable it if they are intentionally debugging.